### PR TITLE
Prevent stale Antigravity responses from being relayed

### DIFF
--- a/discord_bot.js
+++ b/discord_bot.js
@@ -183,7 +183,7 @@ client.once('clientReady', async () => {
         if (res.ok) {
             if (channel) {
                 const msg = await channel.send(`⏰ Job #${meta.number}: \`${meta.message}\``);
-                monitorAIResponse(msg, cdp);
+                monitorAIResponse(msg, cdp, res);
             }
         } else {
             if (channel) await channel.send(`⚠️ Job #${meta.number}: Failed to inject message.`);
@@ -594,7 +594,7 @@ client.on('messageCreate', async message => {
         } catch (e) {
             console.error('Failed to react to message:', e);
         }
-        monitorAIResponse(message, cdp);
+        monitorAIResponse(message, cdp, res);
     } else {
         if (res.error) message.reply(`Error: ${res.error}`);
     }

--- a/selectors.js
+++ b/selectors.js
@@ -1,7 +1,7 @@
 
 export const SELECTORS = {
-    // チャット入力欄: ターミナルの入力欄を除外
-    CHAT_INPUT: 'div[role="textbox"]:not(.xterm-helper-textarea)',
+    // チャット入力欄: 新旧Antigravity UIに対応し、ターミナルの入力欄を除外
+    CHAT_INPUT: 'div[role="textbox"]:not(.xterm-helper-textarea), div[role="combobox"][aria-label="Message input"][contenteditable="true"]',
 
     // 送信ボタン: SVG アイコンのクラス名で判定
     SUBMIT_BUTTON_CONTAINER: 'button',

--- a/src/cdp_manager.js
+++ b/src/cdp_manager.js
@@ -141,6 +141,12 @@ export async function discoverCDP() {
         ));
     }
 
+    // Conversation titles can replace the generic "Antigravity" window title.
+    // Port 9500 is dedicated to this app, so keep any remaining page as a final fallback.
+    if (!target) {
+        target = await pickBestTarget(allTargets.filter(t => t.type === 'page'));
+    }
+
     if (target) {
         const lowPri = isLowPriorityTarget(target);
         console.log(`\n========================================`);

--- a/src/dom_operations.js
+++ b/src/dom_operations.js
@@ -1,5 +1,6 @@
 // --- DOM操作（Antigravityの制御） ---
 import { SELECTORS } from '../selectors.js';
+import { PORTS } from './config.js';
 import { logInteraction } from './logging.js';
 import {
     sanitizeAssistantMarkdown, sanitizeAssistantResponse, extractNarrativeBody,
@@ -212,9 +213,19 @@ export async function injectMessage(cdp, text) {
 
         function getSnapshot(editor) {
             return {
-                messageCount: document.querySelectorAll('[data-message-role]').length,
+                messageCount: document.querySelectorAll('[data-message-role], [role="article"]').length,
+                assistantResponseCount: document.querySelectorAll('.leading-relaxed.select-text').length,
                 editorChars: ((editor && editor.innerText) || '').trim().length,
                 cancelVisible: Boolean(document.querySelector('[data-tooltip-id="input-send-button-cancel-tooltip"]'))
+            };
+        }
+
+        function successfulSubmission(method, before, after) {
+            return {
+                ok: true,
+                method,
+                generationObserved: Boolean(after.cancelVisible),
+                responseObserved: after.assistantResponseCount > before.assistantResponseCount
             };
         }
 
@@ -256,21 +267,40 @@ export async function injectMessage(cdp, text) {
             if (submit) { submit.click(); method = 'click'; }
             else { pressEnter(editor); }
 
+            let submissionConfirmed = false;
+            let latestAfter = before;
             for (let i = 0; i < 8; i++) {
                 await new Promise(r => setTimeout(r, 300));
                 const after = getSnapshot(editor);
+                latestAfter = after;
                 const submitted = after.cancelVisible || after.messageCount > before.messageCount || (before.editorChars > 0 && after.editorChars === 0);
-                if (submitted) return { ok: true, method };
+                if (submitted) {
+                    submissionConfirmed = true;
+                    if (after.cancelVisible || after.assistantResponseCount > before.assistantResponseCount) {
+                        return successfulSubmission(method, before, after);
+                    }
+                }
             }
+
+            if (submissionConfirmed) return successfulSubmission(method, before, latestAfter);
 
             if (method !== 'enter') {
                 pressEnter(editor);
+                submissionConfirmed = false;
+                latestAfter = before;
                 for (let i = 0; i < 6; i++) {
                     await new Promise(r => setTimeout(r, 300));
                     const after = getSnapshot(editor);
+                    latestAfter = after;
                     const submitted = after.cancelVisible || after.messageCount > before.messageCount || (before.editorChars > 0 && after.editorChars === 0);
-                    if (submitted) return { ok: true, method: 'enter' };
+                    if (submitted) {
+                        submissionConfirmed = true;
+                        if (after.cancelVisible || after.assistantResponseCount > before.assistantResponseCount) {
+                            return successfulSubmission('enter', before, after);
+                        }
+                    }
                 }
+                if (submissionConfirmed) return successfulSubmission('enter', before, latestAfter);
             }
             return { ok: false, error: 'submit_not_confirmed' };
         }
@@ -326,11 +356,23 @@ export async function waitForGenerationStart(cdp, timeoutMs = 8000) {
 
 export async function checkApprovalRequired(preferredCdp = null) {
     let targets = [];
-    try {
-        const res = await fetch(`http://127.0.0.1:9222/json/list`);
-        targets = await res.json();
-    } catch (e) {
-        logInteraction('ERROR', '[CHECK_APPROVAL] failed to fetch targets: ' + e.message);
+    let fetchError = null;
+    for (const port of PORTS) {
+        try {
+            const res = await fetch(`http://127.0.0.1:${port}/json/list`);
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const list = await res.json();
+            if (Array.isArray(list)) {
+                targets = list;
+                break;
+            }
+        } catch (e) {
+            fetchError = e;
+        }
+    }
+
+    if (targets.length === 0) {
+        logInteraction('ERROR', `[CHECK_APPROVAL] failed to fetch targets on ports ${PORTS.join(',')}: ${fetchError?.message || 'empty target list'}`);
         if (preferredCdp) targets = [{ webSocketDebuggerUrl: preferredCdp.ws.url, title: 'current' }];
         else return null;
     }
@@ -575,7 +617,10 @@ export async function getLastResponse(cdp) {
 
     const EXP = '(' + function (RAW_LIMIT, REPLY_LIMIT) {
         try {
-            var msgContainer = document.querySelector('.relative.flex.flex-col.gap-y-3.px-4');
+            var messageContainers = Array.from(document.querySelectorAll('.relative.flex.flex-col.gap-y-3'));
+            var msgContainer = messageContainers.filter(function (container) {
+                return container.querySelector('.leading-relaxed.select-text');
+            }).pop();
             if (!msgContainer) return { text: '', debug: 'msgContainer not found' };
 
             var blocks = Array.from(msgContainer.children);

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -6,17 +6,15 @@ import { state } from './state.js';
 import { logInteraction } from './logging.js';
 import { safeReplyTarget, sendResponseEmbeds } from './discord_helpers.js';
 import { checkApprovalRequired, clickApproval, checkIsGenerating, getLastResponse } from './dom_operations.js';
-import { evaluateGenerationActivity } from './monitor_activity.js';
+import { evaluateGenerationActivity, submissionIndicatesActivity } from './monitor_activity.js';
 
-export async function monitorAIResponse(originalMessage, cdp) {
+export async function monitorAIResponse(originalMessage, cdp, submission = null) {
     if (state.isGenerating) return;
     state.isGenerating = true;
     let stableCount = 0;
-    let activityDetected = false;
+    let activityDetected = submissionIndicatesActivity(submission);
     state.lastApprovalMessage = null;
     logInteraction('ACTION', 'Monitoring AI response.');
-
-    await new Promise(r => setTimeout(r, 3000));
 
     const startTime = Date.now();
     const MONITOR_TIMEOUT = 30 * 60 * 1000; // 30分
@@ -243,5 +241,5 @@ export async function monitorAIResponse(originalMessage, cdp) {
         }
     };
 
-    setTimeout(poll, POLLING_INTERVAL);
+    setTimeout(poll, 0);
 }

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -6,12 +6,13 @@ import { state } from './state.js';
 import { logInteraction } from './logging.js';
 import { safeReplyTarget, sendResponseEmbeds } from './discord_helpers.js';
 import { checkApprovalRequired, clickApproval, checkIsGenerating, getLastResponse } from './dom_operations.js';
+import { evaluateGenerationActivity } from './monitor_activity.js';
 
 export async function monitorAIResponse(originalMessage, cdp) {
     if (state.isGenerating) return;
     state.isGenerating = true;
     let stableCount = 0;
-    let generationStarted = false;
+    let activityDetected = false;
     state.lastApprovalMessage = null;
     logInteraction('ACTION', 'Monitoring AI response.');
 
@@ -148,11 +149,39 @@ export async function monitorAIResponse(originalMessage, cdp) {
             }
 
             const generating = await checkIsGenerating(cdp);
-            if (generating && !generationStarted) {
-                generationStarted = true;
+            const activity = evaluateGenerationActivity({
+                activityDetected,
+                generating,
+                elapsedMs: Date.now() - startTime
+            });
+            activityDetected = activity.activityDetected;
+
+            if (activity.startedNow) {
                 logInteraction('generating', 'AI response generation started.');
             }
+
+            if (activity.abortForNoGeneration) {
+                state.isGenerating = false;
+                logInteraction('NO_RESPONSE', 'No new generation signal detected; existing session response was not relayed.');
+                try {
+                    await safeReplyTarget(
+                        originalMessage,
+                        { content: '新しい生成を確認できなかったため、既存セッションの回答は送付しませんでした。必要なら `!lr` で最新回答を手動取得してください。' },
+                        { preferReply: true }
+                    );
+                } catch (replyErr) {
+                    logInteraction('ERROR', `Failed to send no-generation notification: ${replyErr?.message || String(replyErr)}`);
+                }
+                return;
+            }
+
             if (!generating) {
+                // Only a generation triggered by this Discord message may complete
+                // the monitor and relay an assistant response.
+                if (!activity.canCountStablePoll) {
+                    setTimeout(poll, POLLING_INTERVAL);
+                    return;
+                }
                 stableCount++;
                 if (stableCount >= 3) {
                     state.isGenerating = false;

--- a/src/monitor_activity.js
+++ b/src/monitor_activity.js
@@ -1,0 +1,11 @@
+export const GENERATION_START_TIMEOUT = 20 * 1000;
+
+export function evaluateGenerationActivity({ activityDetected, generating, elapsedMs, startTimeoutMs = GENERATION_START_TIMEOUT }) {
+    const nextActivityDetected = activityDetected || generating;
+    return {
+        activityDetected: nextActivityDetected,
+        startedNow: generating && !activityDetected,
+        abortForNoGeneration: !nextActivityDetected && elapsedMs >= startTimeoutMs,
+        canCountStablePoll: nextActivityDetected && !generating
+    };
+}

--- a/src/monitor_activity.js
+++ b/src/monitor_activity.js
@@ -1,5 +1,9 @@
 export const GENERATION_START_TIMEOUT = 20 * 1000;
 
+export function submissionIndicatesActivity(submission) {
+    return Boolean(submission?.generationObserved || submission?.responseObserved);
+}
+
 export function evaluateGenerationActivity({ activityDetected, generating, elapsedMs, startTimeoutMs = GENERATION_START_TIMEOUT }) {
     const nextActivityDetected = activityDetected || generating;
     return {

--- a/tests/test_monitor_activity.mjs
+++ b/tests/test_monitor_activity.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const {
+    GENERATION_START_TIMEOUT,
+    evaluateGenerationActivity
+} = await import('../src/monitor_activity.js');
+
+test('an unchanged idle session cannot count toward response completion', () => {
+    const result = evaluateGenerationActivity({
+        activityDetected: false,
+        generating: false,
+        elapsedMs: GENERATION_START_TIMEOUT - 1
+    });
+
+    assert.equal(result.activityDetected, false);
+    assert.equal(result.abortForNoGeneration, false);
+    assert.equal(result.canCountStablePoll, false);
+});
+
+test('an unchanged idle session is abandoned after the start timeout', () => {
+    const result = evaluateGenerationActivity({
+        activityDetected: false,
+        generating: false,
+        elapsedMs: GENERATION_START_TIMEOUT
+    });
+
+    assert.equal(result.abortForNoGeneration, true);
+    assert.equal(result.canCountStablePoll, false);
+});
+
+test('observed generation enables stable completion polling', () => {
+    const started = evaluateGenerationActivity({
+        activityDetected: false,
+        generating: true,
+        elapsedMs: 1000
+    });
+    const completed = evaluateGenerationActivity({
+        activityDetected: started.activityDetected,
+        generating: false,
+        elapsedMs: 3000
+    });
+
+    assert.equal(started.startedNow, true);
+    assert.equal(started.abortForNoGeneration, false);
+    assert.equal(completed.activityDetected, true);
+    assert.equal(completed.abortForNoGeneration, false);
+    assert.equal(completed.canCountStablePoll, true);
+});

--- a/tests/test_monitor_activity.mjs
+++ b/tests/test_monitor_activity.mjs
@@ -3,8 +3,16 @@ import test from 'node:test';
 
 const {
     GENERATION_START_TIMEOUT,
-    evaluateGenerationActivity
+    evaluateGenerationActivity,
+    submissionIndicatesActivity
 } = await import('../src/monitor_activity.js');
+
+test('only observed generation or a new response counts as submission activity', () => {
+    assert.equal(submissionIndicatesActivity(null), false);
+    assert.equal(submissionIndicatesActivity({ editorCleared: true }), false);
+    assert.equal(submissionIndicatesActivity({ generationObserved: true }), true);
+    assert.equal(submissionIndicatesActivity({ responseObserved: true }), true);
+});
 
 test('an unchanged idle session cannot count toward response completion', () => {
     const result = evaluateGenerationActivity({


### PR DESCRIPTION
## 概要

Discordから送信した際、新しいAntigravity生成を確認できないまま既存セッションの最新回答を返すことを防ぎます。

## 変更内容

- 生成中シグナルまたは新規回答行を観測した場合だけ、回答完了として送信
- 20秒以内に新しい生成が始まらない場合は、既存回答を送らず案内を返信
- 高速に完了する応答のDOM前後差分を監視に引き継ぎ
- 現行Antigravity UIの入力欄・回答コンテナに対応
- 会話名へのウィンドウタイトル変更後もCDP再接続できるフォールバックを追加
- 承認検出が旧ポート `9222` ではなく設定済み `PORTS` を使うよう修正

## 検証

- 全JavaScriptファイルの `node --check`
- `node --test tests/test_monitor_activity.mjs` — 4 tests passed
- `git diff --check`
- 実CDP `9500` で既存回答を返さない負系を確認
- 実CDPでプロンプト注入→生成→完了→回答抽出の正常系を確認
- Bot再起動後のDiscordログイン、CDP再接続、起動完了DMを確認
